### PR TITLE
fix: create temp directory before access

### DIFF
--- a/Intersect GUI Editor/Functions.vb
+++ b/Intersect GUI Editor/Functions.vb
@@ -2,14 +2,18 @@
 
 Module Functions
     Private _rnd As New Random()
+
     Function RandomNumber(ByVal low As Integer, ByVal high As Integer) As Integer
         Return _rnd.Next(low, high)
     End Function
+
     Public Sub ReloadText(ByVal windowname As String, ByVal type As String)
         Dim tempPath As String = Application.StartupPath & "\temp\"
         Dim tempFileName As String
 
         tempFileName = RandomNumber(10000, 10000000)
+
+        Directory.CreateDirectory(tempPath)
 
         Select Case type
             Case "treeview"
@@ -17,7 +21,8 @@ Module Functions
                     Form1.JTokenTreeUserControl1.SaveJson(writer)
                 End Using
             Case "text"
-                My.Computer.FileSystem.WriteAllText(tempPath & "tmp_" & tempFileName & ".json", Form1.fullJson.Text, False)
+                My.Computer.FileSystem.WriteAllText(tempPath & "tmp_" & tempFileName & ".json", Form1.fullJson.Text,
+                                                    False)
                 Form1.JTokenTreeUserControl1.SetJsonSource(Form1.fullJson.Text)
         End Select
 


### PR DESCRIPTION
The `temp` directory is assumed to exist which crashes when that isn't the case.

```
System.IO.DirectoryNotFoundException: Could not find a part of the path 'Intersect GUI Editor\bin\Debug\temp\tmp_7806103.json'.
   at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   at System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   at System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, FileOptions options, String msgPath, Boolean bFromProxy)
   at System.IO.FileStream..ctor(String path, FileMode mode)
   at Intersect_GUI_Editor.Functions.ReloadText(String windowname, String type) in Intersect GUI Editor\Functions.vb:line 16
   at Intersect_GUI_Editor.Form1.Button1_Click(Object sender, EventArgs e) in Intersect GUI Editor\Form1.vb:line 3013
   at System.Windows.Forms.Control.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnClick(EventArgs e)
   at System.Windows.Forms.Button.OnMouseUp(MouseEventArgs mevent)
   at System.Windows.Forms.Control.WmMouseUp(Message& m, MouseButtons button, Int32 clicks)
   at System.Windows.Forms.Control.WndProc(Message& m)
   at System.Windows.Forms.ButtonBase.WndProc(Message& m)
   at System.Windows.Forms.Button.WndProc(Message& m)
   at System.Windows.Forms.NativeWindow.Callback(IntPtr hWnd, Int32 msg, IntPtr wparam, IntPtr lparam)

```